### PR TITLE
Link to Network status page

### DIFF
--- a/static/networks/testnet.json
+++ b/static/networks/testnet.json
@@ -5,6 +5,7 @@
   "Maintainer": "Protocol Labs",
   "Stability": "high",
   "Status": "online",
+  "StatusUrl": "https://filecoin.statuspage.io",
   "NetworkParameters":{
     "SupportedProofTypes":[
       {

--- a/static/networks/testnet.json
+++ b/static/networks/testnet.json
@@ -5,7 +5,6 @@
   "Maintainer": "Protocol Labs",
   "Stability": "high",
   "Status": "online",
-  "StatusUrl": "https://filecoin.statuspage.io",
   "NetworkParameters":{
     "SupportedProofTypes":[
       {
@@ -35,6 +34,10 @@
     {
       "Name":"Latest chain snapshot (full)",
       "Link":"ttps://very-temporary-spacerace-chain-snapshot.s3-us-west-2.amazonaws.com/Spacerace_stateroots_snapshot_latest.car"
+    },
+    {
+      "Name": "Status page and incidents",
+      "Link": "https://filecoin.statuspage.io",
     },
     {
       "Name":"Faucet",


### PR DESCRIPTION
Hi folks! Can you share with me your expected contribution? I want to have the page link to https://filecoin.statuspage.io

Should I update the schema and add that line after the Status? Please advise.